### PR TITLE
Add lexical-binding cookie to elgrep-data.el

### DIFF
--- a/elgrep.el
+++ b/elgrep.el
@@ -2799,6 +2799,7 @@ Unconditionally return the value of `elgrep-data-file'."
   (interactive)
   (when (stringp elgrep-data-file)
     (with-temp-buffer
+      (insert ";;; -*- lexical-binding: t -*-\n")
       (let (print-level print-length)
 	(insert (format "%S" `(setq elgrep-call-list (quote ,elgrep-call-list)))))
       (write-file


### PR DESCRIPTION
## Summary
- Added `lexical-binding` cookie to the dynamically generated `elgrep-data.el` file
- This fixes the warning that appears in Emacs 31 when loading the file

## Test plan
- [x] Load elgrep in Emacs 31
- [x] Let elgrep save its data (e.g., by exiting Emacs after using elgrep-menu)
- [x] Restart Emacs and verify no warning appears about missing lexical-binding
- [x] Verify elgrep-data.el now starts with `;;; -*- lexical-binding: t -*-`

🤖 Generated with [Claude Code](https://claude.ai/code)